### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## What
 
-Run [Outline](https://www.getoultine.com/) on [Cloudron](https://cloudron.io)
+Run [Outline](https://www.getoutline.com/) on [Cloudron](https://cloudron.io)
 
 ## Why
 


### PR DESCRIPTION
Fixes the transposed "tl" in "https://www.getouTLine.com/". The current site (a typo) is a scam site instead of the official outline project site.